### PR TITLE
fix: convert param to number in markStaleIssues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,7 @@ export async function markStaleIssues(toolkit: Toolkit, projectNumber: number, d
     now.setDate(now.getDate() - DAYS_UNTIL_STALE);
     const staleDate = now.toISOString().split('T')[0];
 
-    switch (projectNumber) {
+    switch (Number(projectNumber)) {
         case 27: {
             const query = `
                 query {


### PR DESCRIPTION
Even when we use typescript in this project, the compiled javascript doesn't do any checks or convertions...

Before:
```
async function markStaleIssues(toolkit, projectNumber, dryRun) {
  const DAYS_UNTIL_STALE = 180;
  const now = /* @__PURE__ */ new Date();
  now.setDate(now.getDate() - DAYS_UNTIL_STALE);
  const staleDate = now.toISOString().split("T")[0];
  switch (projectNumber) {
    case 27: {
```

After:
```
async function markStaleIssues(toolkit, projectNumber, dryRun) {
  const DAYS_UNTIL_STALE = 180;
  const now = /* @__PURE__ */ new Date();
  now.setDate(now.getDate() - DAYS_UNTIL_STALE);
  const staleDate = now.toISOString().split("T")[0];
  switch (Number(projectNumber)) {
    case 27: {
```