### PR TITLE
fix: markStaleIssues logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -512,7 +512,7 @@ export async function markStaleIssues(toolkit: Toolkit, projectNumber: number, d
 
                 const statusInProject = issue.projectItems.nodes.find((projectItem) => projectItem.project.number == 27)?.fieldValueByName.name;
 
-                if (priorityLabel && (priorityLabel.split('/')[1] === "low" || statusInProject == "Backlog") && parentIssueType != "Epic") {
+                if (((priorityLabel && priorityLabel.split('/')[1] === "low") || statusInProject == "Backlog") && parentIssueType != "Epic") {
                     if (dryRun) {
                         toolkit.core.info(`Would set "${issue.title}" (${issue.url}) to AboutToClose`);
                         continue;


### PR DESCRIPTION
There is a logic issue in the current markStaleIssues condition. The issue always needs a priority label.
With this change the label is optional, as we also check the status in the project.