### PR TITLE
fix: getProjectInfo variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ export async function getProjectInfo(toolkit: Toolkit, data: { number: number, o
         `,
         {
             organization: data.organization ?? "shopware",
-            number: data.number,
+            projectNumber: data.number,
         }
     )
 


### PR DESCRIPTION
The variable name in the GraphQL is `projectNumber`.