### PR TITLE
fix: branch cleanup

### DIFF
--- a/src/services/branch.ts
+++ b/src/services/branch.ts
@@ -116,7 +116,7 @@ export async function cleanupBranches(toolkit: Toolkit, repo: string, organizati
         toolkit.github.rest.git.deleteRef({
             owner: organization,
             repo: repo,
-            ref: branch
+            ref: `heads/${branch}`
         });
     }
 }


### PR DESCRIPTION
The Github api wants the whole `refs/heads/$BRANCH` path. `refs/` is already given by the API endpoint, so we just need to add `heads/$branch`.