### PR TITLE
feat: add rate-limiting

### DIFF
--- a/src/services/branch.ts
+++ b/src/services/branch.ts
@@ -1,5 +1,6 @@
 import { Toolkit } from "../types";
 import { isDryRun } from "../util/dry_run";
+import { rateLimitedRun } from "../util/rate_limiting";
 
 export async function getOldBranches(toolkit: Toolkit, repo: string, excludeRegex: string | RegExp = "", organization: string = "shopware"): Promise<string[] | null> {
     const DAYS_UNTIL_STALE = 6 * 30;
@@ -107,16 +108,23 @@ export async function cleanupBranches(toolkit: Toolkit, repo: string, organizati
         toolkit.core.error("No old branches found!");
         return;
     }
-    for (const branch of branches) {
-        if (isDryRun()) {
+
+    toolkit.core.info(`Cleaning up ${branches.length} branch(es) with rate limiting...`);
+
+    if (isDryRun()) {
+        for (const branch of branches) {
             toolkit.core.info(`Would delete ${branch}`);
-            continue;
         }
+        return;
+    }
+
+    // Rate-limit the actual deletions
+    await rateLimitedRun(branches, async branch => {
         toolkit.core.info(`Deleting ${branch}...`);
-        toolkit.github.rest.git.deleteRef({
+        await toolkit.github.rest.git.deleteRef({
             owner: organization,
             repo: repo,
             ref: `heads/${branch}`
         });
-    }
+    });
 }

--- a/src/util/rate_limiting.ts
+++ b/src/util/rate_limiting.ts
@@ -1,0 +1,19 @@
+export async function rateLimitedRun<T>(items: T[], fn: (item: T) => Promise<void>, max_concurrency: number = 10, delay_ms: number = 1000): Promise<void> {
+    // Split items into chunks of max_concurrency
+    const chunks = [];
+    for (let i = 0; i < items.length; i += max_concurrency) {
+        chunks.push(items.slice(i, i + max_concurrency));
+    }
+
+    for (const chunk of chunks) {
+        // Run all items in the chunk concurrently
+        await Promise.all(chunk.map(item => fn(item)));
+
+        // Add a small delay between batches to respect the secondary rate limit
+        const nextChunk = chunks[chunks.indexOf(chunk) + 1];
+        if (nextChunk) {
+            await new Promise(resolve => setTimeout(resolve, delay_ms));
+        }
+    }
+}
+


### PR DESCRIPTION
Some workflows like the branch cleanup are too fast for Github's API and needs rate-limiting.
I've built it as a utility, so we can reuse it in different workflows.