### PR TITLE
ci: make slack handle resolution observable

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -683,7 +683,10 @@ export async function getVerifiedDomainEmails(toolkit: Toolkit, login: string, o
             organization
         });
 
-    return res.user.organizationVerifiedDomainEmails;
+    const emails = res.user?.organizationVerifiedDomainEmails ?? [];
+    toolkit.core.info(`Resolved verified domain emails for ${login} in ${organization}: ${JSON.stringify(emails)}`);
+
+    return emails;
 }
 
 /**

--- a/src/api/slack.ts
+++ b/src/api/slack.ts
@@ -17,7 +17,14 @@ export class SlackClient {
         } catch (error: unknown) {
             if (isWebAPIPlatformError(error)) {
                 if (error.code == ErrorCode.PlatformError) {
-                    toolkit.core.error("Failed to get user: " + error.data.error);
+                    // `users_not_found` just means no Slack account uses this email.
+                    // That is an expected outcome while probing multiple emails, so
+                    // don't surface it as an error annotation.
+                    if (error.data.error === "users_not_found") {
+                        toolkit.core.info(`No Slack user found for email ${email}.`);
+                    } else {
+                        toolkit.core.error("Failed to get user: " + error.data.error);
+                    }
                     toolkit.core.debug(JSON.stringify(error.data));
                 } else {
                     throw error;

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -40,6 +40,8 @@ export async function getSlackUserByEmail(toolkit: Toolkit, emails: string[]): P
 
     const slackClient = new SlackClient(process.env.SLACK_TOKEN);
 
+    toolkit.core.info(`Looking up Slack user for emails: ${JSON.stringify(emails)}`);
+
     for (const email of emails) {
         if (!email || email.trim() === '') {
             continue;
@@ -49,6 +51,8 @@ export async function getSlackUserByEmail(toolkit: Toolkit, emails: string[]): P
         if (!user) {
             continue;
         }
+
+        toolkit.core.info(`Found Slack user ${user.name ?? user.id} for email ${email}.`);
 
         return user;
     }


### PR DESCRIPTION
## What

Adds visibility to the GitHub-user → Slack-handle resolution used by the saas-template `build.yml` to set the mcli version owner, and stops an expected Slack lookup miss from looking like a failure.

## Why

Building `build.yml` showed `Error: Failed to get user: users_not_found` with no way to see which email was resolved. Root cause: `getVerifiedDomainEmails` returns multiple candidate emails (e.g. `jb@` and `j.buecker@`); the first misses in Slack and the loop *correctly* falls through to the second — but the miss was logged at `error` severity and the successful match was silent, so it read as a hard failure.

## Changes

- `getVerifiedDomainEmails` logs the resolved verified-domain emails (and is now null-safe on a missing GraphQL user).
- `getSlackUserByEmail` logs the email list it probes and which email matched.
- `getUserByEmail` logs the expected `users_not_found` case as `info` instead of `error`; other platform errors still error out.

No control-flow change to the resolution loop — it already tried every candidate email.

## Verification

Observed in a saas-template build run:

```
Resolved verified domain emails for janbuecker in shopware: ["jb@shopware.com","j.buecker@shopware.com"]
Looking up Slack user for emails: ["jb@shopware.com","j.buecker@shopware.com"]
No Slack user found for email jb@shopware.com.
Found Slack user j.buecker for email j.buecker@shopware.com.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)