### PR TITLE
ci: pin npm to version 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
The newest npm version doesn't bundle `sigstore` currently...
See: https://github.com/npm/cli/issues/9722